### PR TITLE
Always return empty array and object from `alwaysEmptyObject` and `alwaysEmptyArray`

### DIFF
--- a/packages/ramda-extension/src/__tests__/alwaysEmptyArray-test.js
+++ b/packages/ramda-extension/src/__tests__/alwaysEmptyArray-test.js
@@ -4,4 +4,8 @@ describe('alwaysEmptyArray', () => {
 	it('returns []', () => {
 		expect(alwaysEmptyArray()).toEqual([]);
 	});
+
+	it('always returns a new array', () => {
+		expect(alwaysEmptyArray()).not.toBe(alwaysEmptyArray());
+	});
 });

--- a/packages/ramda-extension/src/__tests__/alwaysEmptyObject-test.js
+++ b/packages/ramda-extension/src/__tests__/alwaysEmptyObject-test.js
@@ -4,4 +4,8 @@ describe('alwaysEmptyObject', () => {
 	it('returns {}', () => {
 		expect(alwaysEmptyObject()).toEqual({});
 	});
+
+	it('always returns a new object', () => {
+		expect(alwaysEmptyObject()).not.toBe(alwaysEmptyObject());
+	});
 });

--- a/packages/ramda-extension/src/alwaysEmptyArray.js
+++ b/packages/ramda-extension/src/alwaysEmptyArray.js
@@ -1,8 +1,8 @@
-import { always } from 'ramda';
+import alwaysNew from './internal/alwaysNew';
 import { emptyArray } from './internal/primitives';
 
 /**
- * Always returns empty array.
+ * Always returns a new empty array.
  *
  * @func
  * @category Function
@@ -13,6 +13,6 @@ import { emptyArray } from './internal/primitives';
  *
  * @sig a -> Array
  */
-const alwaysEmptyArray = always(emptyArray);
+const alwaysEmptyArray = alwaysNew(emptyArray);
 
 export default alwaysEmptyArray;

--- a/packages/ramda-extension/src/alwaysEmptyObject.js
+++ b/packages/ramda-extension/src/alwaysEmptyObject.js
@@ -1,8 +1,8 @@
-import { always } from 'ramda';
+import alwaysNew from './internal/alwaysNew';
 import { emptyObject } from './internal/primitives';
 
 /**
- * Always returns empty object.
+ * Always returns a new empty object.
  *
  * @func
  * @category Function
@@ -13,6 +13,6 @@ import { emptyObject } from './internal/primitives';
  *
  * @sig a -> Object
  */
-const alwaysEmptyObject = always(emptyObject);
+const alwaysEmptyObject = alwaysNew(emptyObject);
 
 export default alwaysEmptyObject;

--- a/packages/ramda-extension/src/internal/alwaysNew.js
+++ b/packages/ramda-extension/src/internal/alwaysNew.js
@@ -8,7 +8,7 @@ import thunkify from '../internal/thunkify';
  * @func
  * @example
  *
- * 	const alwaysNewArray = alwaysNew([]);
+ *  const alwaysNewArray = alwaysNew([]);
  *  const a = alwaysNewArray();
  *  const b = alwaysNewArray();
  *  // a !== b

--- a/packages/ramda-extension/src/internal/alwaysNew.js
+++ b/packages/ramda-extension/src/internal/alwaysNew.js
@@ -1,0 +1,19 @@
+import { clone } from 'ramda';
+import thunkify from '../internal/thunkify';
+
+/**
+ * Returns a function that creates new instances of whatever argument
+ * is passed in each time it's called.
+ *
+ * @func
+ * @example
+ *
+ * 	const alwaysNewArray = alwaysNew([]);
+ *  const a = alwaysNewArray();
+ *  const b = alwaysNewArray();
+ *  // a !== b
+ *
+ */
+const alwaysNew = thunkify(clone);
+
+export default alwaysNew;

--- a/packages/ramda-extension/src/internal/thunkify.js
+++ b/packages/ramda-extension/src/internal/thunkify.js
@@ -1,0 +1,19 @@
+import { curryN } from 'ramda';
+
+/**
+ * Creates a thunk out of a function. A thunk delays a calculation until
+ * its result is needed, providing lazy evaluation of arguments.
+ *
+ * @func
+ * @example
+ *
+ *      R_.thunkify(R.identity)(42)(); //=> 42
+ *      R_.thunkify((a, b) => a + b)(25, 17)(); //=> 42
+ * @sig ((a, b, ..., j) -> k) -> (a, b, ..., j) -> (() -> k)
+ */
+const thunkify = (fn) => curryN(fn.length, (...args) => () => fn(...args));
+
+// NOTE (23/06/18): `thunkify` was added to Ramda core but it's
+// still unreleased. We should remove this module once it becomes available.
+// @see https://github.com/ramda/ramda/pull/2551
+export default thunkify;

--- a/packages/ramda-extension/src/internal/thunkify.js
+++ b/packages/ramda-extension/src/internal/thunkify.js
@@ -1,4 +1,6 @@
-import { curryN } from 'ramda';
+import { curry, apply, useWith, unapply } from 'ramda';
+
+const alwaysApply = curry((fn, args) => () => apply(fn, args));
 
 /**
  * Creates a thunk out of a function. A thunk delays a calculation until
@@ -9,9 +11,10 @@ import { curryN } from 'ramda';
  *
  *      R_.thunkify(R.identity)(42)(); //=> 42
  *      R_.thunkify((a, b) => a + b)(25, 17)(); //=> 42
+ *
  * @sig ((a, b, ..., j) -> k) -> (a, b, ..., j) -> (() -> k)
  */
-const thunkify = (fn) => curryN(fn.length, (...args) => () => fn(...args));
+const thunkify = useWith(unapply, [alwaysApply]);
 
 // NOTE (23/06/18): `thunkify` was added to Ramda core but it's
 // still unreleased. We should remove this module once it becomes available.


### PR DESCRIPTION
Fixes #97.

Uses Ramda's yet-to-be-released `thunkify` function + `clone` to ensure that `alwaysEmpty*` functions always return new instances of their return values.

```js
// Before
alwaysEmptyArray() === alwaysEmptyArray(); // true
alwaysEmptyObject() === alwaysEmptyObject(); // true

// After
alwaysEmptyArray() === alwaysEmptyArray(); // false
alwaysEmptyObject() === alwaysEmptyObject(); // false
```
