### PR TITLE
Fix doc of lastArg

### DIFF
--- a/packages/ramda-extension-docs/docs/index.html
+++ b/packages/ramda-extension-docs/docs/index.html
@@ -4487,7 +4487,7 @@ action.type === actionTypes.ITEM_REQUEST; <span class="hljs-comment">// true</sp
 
 
 
-            <div class="description"><p>Takes first argument from the arguments</p>
+            <div class="description"><p>Takes last argument from the arguments</p>
 </div>
 
 

--- a/packages/ramda-extension-docs/public/docs/index.html
+++ b/packages/ramda-extension-docs/public/docs/index.html
@@ -4487,7 +4487,7 @@ action.type === actionTypes.ITEM_REQUEST; <span class="hljs-comment">// true</sp
 
 
 
-            <div class="description"><p>Takes first argument from the arguments</p>
+            <div class="description"><p>Takes last argument from the arguments</p>
 </div>
 
 

--- a/packages/ramda-extension/src/lastArg.js
+++ b/packages/ramda-extension/src/lastArg.js
@@ -1,7 +1,7 @@
 import { nthArg } from 'ramda';
 
 /**
- * Takes first argument from the arguments
+ * Takes last argument from the arguments
  *
  * @func
  * @category Function


### PR DESCRIPTION
The description of `lastArg` said, that it takes the _first_ argument, while of course it takes the _last_ argument.