### PR TITLE
fix documentation for flipIncludes function

### DIFF
--- a/packages/ramda-extension/src/flipIncludes.js
+++ b/packages/ramda-extension/src/flipIncludes.js
@@ -13,7 +13,7 @@ import { flip, includes } from 'ramda';
  * @example
  *
  *    R_.flipIncludes(['e', 'f'], 'e') // true
- *    R_.flipIncludes(['a', 'f'], 'a') // false
+ *    R_.flipIncludes(['e', 'f'], 'a') // false
  *
  * @sig [a] -> b -> Boolean
  */

--- a/packages/ramda-extension/src/notFlipInclude.js
+++ b/packages/ramda-extension/src/notFlipInclude.js
@@ -14,7 +14,7 @@ import flipIncludes from './flipIncludes';
  * @example
  *
  *    R_.notFlipInclude(['e', 'f'], 'e') // false
- *    R_.notFlipInclude(['a', 'f'], 'a') // true
+ *    R_.notFlipInclude(['e', 'f'], 'a') // true
  *
  * @sig [a] -> b -> Boolean
  */


### PR DESCRIPTION
There was both examples true
R_.flipIncludes(['e', 'f'], 'e') // true
R_.flipIncludes(['a', 'f'], 'a') // false 

i just change letter 'a' to letter 'e'.