### PR TITLE
removed usage any comparison in __tests__

### DIFF
--- a/packages/ramda-extension/src/__tests__/isNumber-test.js
+++ b/packages/ramda-extension/src/__tests__/isNumber-test.js
@@ -1,14 +1,19 @@
-import { any, equals } from 'ramda';
+import { all, equals } from 'ramda';
 import { isNumber } from '../';
 
 describe('isNumber', () => {
 	it('returns true for numbers', () => {
-		expect(any(equals(true), [isNumber(Infinity), isNumber(NaN), isNumber(1), isNumber(1.1)])).toBe(true);
+		expect(all(equals(true), [
+			isNumber(Infinity),
+			isNumber(NaN),
+			isNumber(1),
+			isNumber(1.1),
+		])).toBeTruthy();
 	});
 
 	it('returns false for infinite numbers and non-number types', () => {
 		expect(
-			any(equals(true), [
+			all(equals(false), [
 				isNumber(''),
 				isNumber(() => {}),
 				isNumber(false),
@@ -17,6 +22,6 @@ describe('isNumber', () => {
 				isNumber({}),
 				isNumber([]),
 			])
-		).toBe(false);
+		).toBeTruthy();
 	});
 });

--- a/packages/ramda-extension/src/__tests__/isNumeric-test.js
+++ b/packages/ramda-extension/src/__tests__/isNumeric-test.js
@@ -1,24 +1,27 @@
-import R from 'ramda';
+import { all, equals } from 'ramda';
 import { isNumeric } from '../';
 
 describe('isNumeric', () => {
 	it('returns true for finite numbers', () => {
-		expect(R.any(R.equals(true), [isNumeric(-1), isNumeric(0), isNumeric(1), isNumeric(1.1)])).toBe(true);
+		expect(all(equals(true), [
+			isNumeric(-1),
+			isNumeric(0),
+			isNumeric(1),
+			isNumeric(1.1),
+		])).toBeTruthy();
 	});
 
 	it('returns false for infinite numbers and non-number types', () => {
-		expect(
-			R.any(R.equals(true), [
-				isNumeric(Infinity),
-				isNumeric(NaN),
-				isNumeric(''),
-				isNumeric(() => {}),
-				isNumeric(false),
-				isNumeric(null),
-				isNumeric(undefined),
-				isNumeric({}),
-				isNumeric([]),
-			])
-		).toBe(false);
+		expect(all(equals(false), [
+			isNumeric(Infinity),
+			isNumeric(NaN),
+			isNumeric(''),
+			isNumeric(() => {}),
+			isNumeric(false),
+			isNumeric(null),
+			isNumeric(undefined),
+			isNumeric({}),
+			isNumeric([]),
+		])).toBeTruthy();
 	});
 });


### PR DESCRIPTION
@tommmyy I removed usage of any function in __tests__, cause of logical errors. 
And for now didn't use equalsToTrue, not sure if dependency in ramda-extension tests to ramda-extension function is correct approach.

`expect(any(equals(true), [...]))toBe(true);`
-> logical error, satisfied if only one is true

`expect(any(equals(true), [...])).toBe(false);`
-> for not finding any true value is good, but it really doesn't tests if return value is false, only that none is true. 