### PR TITLE
Fix toSnakeCase bug when using camelCase strings

### DIFF
--- a/packages/ramda-extension/src/__tests__/splitByNonDowncaseAlphaNumeric-test.js
+++ b/packages/ramda-extension/src/__tests__/splitByNonDowncaseAlphaNumeric-test.js
@@ -1,0 +1,12 @@
+import { splitByNonDowncaseAlphaNumeric } from '../';
+
+describe('splitByNonDowncaseAlphaNumeric', () => {
+	describe('should split string by non-alphanumeric, non-downcased characters', () => {
+		const splitByNonAlphaNumericUtil = (str, result) =>
+			it(`${str} to be ${result}`, () => expect(splitByNonDowncaseAlphaNumeric(str)).toEqual(result));
+
+		splitByNonAlphaNumericUtil('fooBar', ['foo', 'Bar']);
+		splitByNonAlphaNumericUtil('FooBar', ['Foo', 'Bar']);
+		splitByNonAlphaNumericUtil('hello world AND universe', ['hello', 'world', 'AND', 'universe']);
+	});
+});

--- a/packages/ramda-extension/src/__tests__/toSnakeCase-test.js
+++ b/packages/ramda-extension/src/__tests__/toSnakeCase-test.js
@@ -9,6 +9,7 @@ describe('toSnakeCase', () => {
 		toSnakeCaseUtil('hello-', 'hello');
 		toSnakeCaseUtil('   hello  ', 'hello');
 		toSnakeCaseUtil('hello world', 'hello_world');
-		toSnakeCaseUtil('hello world AND univerSe', 'hello_world_and_universe');
+		toSnakeCaseUtil('hello world AND universe', 'hello_world_and_universe');
+		toSnakeCaseUtil('fooBar', 'foo_bar');
 	});
 });

--- a/packages/ramda-extension/src/index.js
+++ b/packages/ramda-extension/src/index.js
@@ -66,6 +66,7 @@ export { default as toDotCase } from './toDotCase';
 export { default as toScreamingSnakeCase } from './toScreamingSnakeCase';
 export { default as listToString } from './listToString';
 export { default as splitByNonAlphaNumeric } from './splitByNonAlphaNumeric';
+export { default as splitByNonDowncaseAlphaNumeric } from './splitByNonDowncaseAlphaNumeric';
 export { default as constructRegExp } from './constructRegExp';
 export { default as rejectNil } from './rejectNil';
 export { default as rejectEq } from './rejectEq';

--- a/packages/ramda-extension/src/internal/nonDowncaseAlphaNumericRegexp.js
+++ b/packages/ramda-extension/src/internal/nonDowncaseAlphaNumericRegexp.js
@@ -1,0 +1,4 @@
+/**
+ * @private
+ */
+export const nonDowncaseAlphaNumericRegexp = /(?=[A-Z][a-z0-9]).*?|\W/g;

--- a/packages/ramda-extension/src/splitByNonDowncaseAlphaNumeric.js
+++ b/packages/ramda-extension/src/splitByNonDowncaseAlphaNumeric.js
@@ -1,0 +1,25 @@
+import { o, equals, map, trim, split, reject } from 'ramda';
+import { nonDowncaseAlphaNumericRegexp } from './internal/nonDowncaseAlphaNumericRegexp';
+import { emptyString } from './internal/primitives';
+
+/**
+ * Splits string into list. Delimiter is every sequence of non-alphanumerical
+ * and non-downcased values.
+ *
+ * @func
+ * @category String
+ *
+ * @example
+ *
+ *        R_.splitByNonDowncaseAlphaNumeric('fooBar'); // ['foo', 'Bar']
+ *        R_.splitByNonDowncaseAlphaNumeric('foo AND bar and fooBar') // ['foo', 'AND', 'bar', and', 'foo', Bar']
+ *
+ * @sig String -> [String]
+ *
+ */
+const splitByNonDowncaseAlphaNumeric = o(
+	reject(equals(emptyString)),
+	o(map(trim), split(nonDowncaseAlphaNumericRegexp))
+);
+
+export default splitByNonDowncaseAlphaNumeric;

--- a/packages/ramda-extension/src/toSnakeCase.js
+++ b/packages/ramda-extension/src/toSnakeCase.js
@@ -1,5 +1,5 @@
 import { o, map, toLower } from 'ramda';
-import splitByNonAlphaNumeric from './splitByNonAlphaNumeric';
+import splitByNonDowncaseAlphaNumeric from './splitByNonDowncaseAlphaNumeric';
 import joinWithUnderscore from './joinWithUnderscore';
 
 /**
@@ -13,12 +13,13 @@ import joinWithUnderscore from './joinWithUnderscore';
  *        R_.toSnakeCase('hello-world')		// 'hello_world'
  *        R_.toSnakeCase('hello- world')		// 'hello_world'
  *        R_.toSnakeCase('  hello-/ world/ ')	// 'hello_world'
+ *        R_.toSnakeCase('helloWorld')	// 'hello_world'
  *
  * @sig String -> String
  */
 const toSnakeCase = o(
 	joinWithUnderscore,
-	o(map(toLower), splitByNonAlphaNumeric)
+	o(map(toLower), splitByNonDowncaseAlphaNumeric)
 );
 
 export default toSnakeCase;


### PR DESCRIPTION
The regex that was previously used to convert strings to snake_case did
not account for camelCase or StartCamelCase strings, so it simply
downcased the entire string and returned that.

This adds a new regex that is used to handle camelCase and StartCamelCase
strings, as well as the strings previously present in the test cases.

This also adds a new function called `splitByNonDowncaseAlphaNumeric`
that will split a string based on this new regex, trim whitespace from
all strings, and then reject empty strings.

Fixes #169

**Checklist**

- [ ] issue is linked
- [ ] changes are well described
- [ ] tests are included

---

Be in accordance with the latest [Code of Conduct](https://github.com/tommmyy/ramda-extension/blob/master/CODE_OF_CONDUCT.md) and [Guideslines of Contributing](https://github.com/tommmyy/ramda-extension/blob/master/CONTRIBUTING.md).
