### PR TITLE
feat: add toUpperFirst alias toTitleCase

### DIFF
--- a/packages/ramda-extension/src/index.js
+++ b/packages/ramda-extension/src/index.js
@@ -53,6 +53,7 @@ export { default as containsAny } from './containsAny';
 export { default as containsNone } from './containsNone';
 export { default as unfoldObjectDots } from './unfoldObjectDots';
 export { default as toUpperFirst } from './toUpperFirst';
+export { default as toTitleCase } from './toTitleCase';
 export { default as toLowerFirst } from './toLowerFirst';
 export { default as toCamelCase } from './toCamelCase';
 export { default as toPascalCase } from './toPascalCase';

--- a/packages/ramda-extension/src/toTitleCase.js
+++ b/packages/ramda-extension/src/toTitleCase.js
@@ -1,0 +1,18 @@
+import toUpperFirst from './toUpperFirst';
+
+/**
+ * Alias for `toUpperFirst`.
+ *
+ * @func
+ * @category String
+ * @example
+ *
+ *        R_.toUpperFirst('') // ''
+ *        R_.toUpperFirst('hello world') // 'Hello world'
+ *
+ * @see toUpperFirst
+ * @sig String -> String
+ */
+const toTitleCase = toUpperFirst;
+
+export default toTitleCase;


### PR DESCRIPTION
in my experience, TitleCase is a much more common way to express toUpperFirst.
This will help others find a solution to title casing in ramda.

**Checklist**

- [ ] issue is linked
- [x] changes are well described
- [ ] tests are included (NA: just an alias)

---

Be in accordance with the latest [Code of Conduct](https://github.com/tommmyy/ramda-extension/blob/master/CODE_OF_CONDUCT.md) and [Guideslines of Contributing](https://github.com/tommmyy/ramda-extension/blob/master/CONTRIBUTING.md).
